### PR TITLE
Fix deprecation warning about FInputGesture

### DIFF
--- a/Source/BlueprintUe/Private/BlueprintUeCommands.cpp
+++ b/Source/BlueprintUe/Private/BlueprintUeCommands.cpp
@@ -4,7 +4,7 @@
 
 void FBlueprintUeCommands::RegisterCommands()
 {
-	UI_COMMAND(OpenPluginWindow, "blueprintUE", "Open blueprintUE", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(OpenPluginWindow, "blueprintUE", "Open blueprintUE", EUserInterfaceActionType::Button, FInputChord());
 }
 
 #undef LOCTEXT_NAMESPACE


### PR DESCRIPTION
- Gesture is deprecated, should now be Chord

I'm just following the recommendations from the compiler, I haven't tested, but given that this is just being used to fill in an extra parameter in the UI_COMMAND() macro call, I don't think it should have any effect (other than to get rid of the deprecation warning).