### PR TITLE
Fix Api memory leak by moving Api object to the module singleton

### DIFF
--- a/Source/BlueprintUe/Private/Api.cpp
+++ b/Source/BlueprintUe/Private/Api.cpp
@@ -14,8 +14,8 @@ void Api::CreateBlueprint(TFunction<void(FString, TSharedPtr<FJsonObject>)> OnSu
 	HttpRequest->SetURL(Settings->Hostname + "/api/upload");
 	HttpRequest->SetVerb("POST");
 	HttpRequest->SetTimeout(1000);
-	HttpRequest->SetHeader("X-Token",Settings->ApiKey);
-	HttpRequest->SetHeader("Content-Type","application/x-www-form-urlencoded");
+	HttpRequest->SetHeader("X-Token", Settings->ApiKey);
+	HttpRequest->SetHeader("Content-Type", "application/x-www-form-urlencoded");
 
 	Exposure = Exposure.ToLower();
 	if (Expiration == "Never")
@@ -34,7 +34,7 @@ void Api::CreateBlueprint(TFunction<void(FString, TSharedPtr<FJsonObject>)> OnSu
 	{
 		Expiration = "604800";
 	}
-	
+
 	const FString PostContent = FString::Printf(TEXT("title=%s&exposure=%s&expiration=%s&version=%s&blueprint=%s"),
 		*FGenericPlatformHttp::UrlEncode(Title),
 		*FGenericPlatformHttp::UrlEncode(Exposure),
@@ -43,7 +43,7 @@ void Api::CreateBlueprint(TFunction<void(FString, TSharedPtr<FJsonObject>)> OnSu
 		*FGenericPlatformHttp::UrlEncode(Blueprint)
 	);
 	HttpRequest->SetContentAsString(PostContent);
-	
+
 	HttpRequest->ProcessRequest();
 }
 
@@ -54,11 +54,11 @@ void Api::OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Res
 		OnError("error");
 		return;
 	}
-	
+
 	TSharedPtr<FJsonObject> JSONObject;
 	const TSharedRef<TJsonReader<>> JSONReader = TJsonReaderFactory<>::Create(*Response->GetContentAsString());
 	FJsonSerializer::Deserialize(JSONReader, JSONObject);
-	
+
 	if (Response->GetResponseCode() >= 400)
 	{
 		if (JSONObject)

--- a/Source/BlueprintUe/Private/SCreateBlueprint.cpp
+++ b/Source/BlueprintUe/Private/SCreateBlueprint.cpp
@@ -3,6 +3,7 @@
 #include "Api.h"
 #include "Widgets/Input/SMultiLineEditableTextBox.h"
 #include "Widgets/Layout/SScrollBox.h"
+#include "BlueprintUe.h"
 
 void SCreateBlueprint::Construct( const FArguments& InArgs )
 {
@@ -276,8 +277,8 @@ FReply SCreateBlueprint::CreateFromSlate()
 	CurrentError = "";
 	CreateButton->SetEnabled(false);
 
-	Api* API = new Api();
-	API->CreateBlueprint(OnAPISuccess, OnAPIError, Title, *CurrentExposure, *CurrentExpiration, *CurrentUEVersion, Blueprint);
+	Api& Api = FBlueprintUeModule::Get().GetApi();
+	Api.CreateBlueprint(OnAPISuccess, OnAPIError, Title, *CurrentExposure, *CurrentExpiration, *CurrentUEVersion, Blueprint);
 
 	return FReply::Handled();
 }

--- a/Source/BlueprintUe/Public/Api.h
+++ b/Source/BlueprintUe/Public/Api.h
@@ -9,8 +9,8 @@ public:
 	Api(){
 		Settings = GetMutableDefault<UBlueprintUeSettings>();
 	}
-	void CreateBlueprint(TFunction<void(FString, TSharedPtr<FJsonObject>)> OnSuccess, TFunction<void(FString)> OnError, FString Title, FString Exposure, FString Expiration, FString UEVersion, FString Blueprint);
 
+	void CreateBlueprint(TFunction<void(FString, TSharedPtr<FJsonObject>)> OnSuccess, TFunction<void(FString)> OnError, FString Title, FString Exposure, FString Expiration, FString UEVersion, FString Blueprint);
 private:
 	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> HttpRequest = FHttpModule::Get().CreateRequest();
 	void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);

--- a/Source/BlueprintUe/Public/BlueprintUe.h
+++ b/Source/BlueprintUe/Public/BlueprintUe.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "HttpModule.h"
+#include "Api.h"
 
 class FToolBarBuilder;
 class FMenuBuilder;
@@ -14,9 +15,15 @@ public:
 	virtual void ShutdownModule() override;
 	
 	void PluginButtonClicked();
-	
-private:
 
+	Api& GetApi() { return Api; }
+
+	static FBlueprintUeModule& Get()
+	{
+		static const FName ModuleName = "BlueprintUe";
+		return FModuleManager::LoadModuleChecked<FBlueprintUeModule>(ModuleName);
+	}
+private:
 	void RegisterMenus();
 	void RegisterSettings();
 	void UnregisterSettings();
@@ -24,4 +31,5 @@ private:
 
 	TSharedRef<class SDockTab> OnSpawnPluginTab(const class FSpawnTabArgs& SpawnTabArgs);
 	TSharedPtr<class FUICommandList> PluginCommands;
+	Api Api;
 };


### PR DESCRIPTION
# Description

This PR removes the allocation of an Api object everytime the user submits a blueprint. The Api object has been moved to the module singleton, since it acts as a general "request manager" and should live as long as the editor.